### PR TITLE
Add color scheme for the kitty terminal emulator

### DIFF
--- a/kitty/Makefile
+++ b/kitty/Makefile
@@ -1,0 +1,19 @@
+LUNARIZE=python3 ../lunarize.py
+LIGHT_THEME=../lunaria-light.json
+DARK_THEME=../lunaria-dark.json
+ECLIPSE_THEME=../lunaria-eclipse.json
+
+all: light.conf dark.conf eclipse.conf
+clean:
+	$(RM) light.conf dark.conf eclipse.conf
+
+light.conf: template.conf $(LIGHT_THEME)
+	$(LUNARIZE) $(LIGHT_THEME) $< $@
+
+dark.conf: template.conf $(DARK_THEME)
+	$(LUNARIZE) $(DARK_THEME) $< $@
+
+eclipse.conf: template.conf $(ECLIPSE_THEME)
+	$(LUNARIZE) $(ECLIPSE_THEME) $< $@
+
+.PHONY: all clean

--- a/kitty/README.md
+++ b/kitty/README.md
@@ -1,0 +1,11 @@
+Color scheme for the [kitty](https://sw.kovidgoyal.net/kitty/index.html)
+terminal emulator.
+
+Run `make` and copy the generated `.conf` of your choice to the kitty config
+directory.
+
+To use it, you have to include it in your `kitty.conf`.
+
+```
+include light.conf
+```

--- a/kitty/template.conf
+++ b/kitty/template.conf
@@ -17,15 +17,15 @@ inactive_tab_foreground  @fg@
 inactive_tab_background  @deEmphBg@
 tab_bar_background       @deEmphBg@
 
-selection_foreground     @fg@
-selection_background     @bgLightYellow@
+selection_foreground     @bg@
+selection_background     @bgYellow@
 
-mark1_foreground         @fg@
-mark1_background         @bgBlue@
-mark2_foreground         @fg@
-mark2_background         @bgYellow@
+mark1_foreground         @bg@
+mark1_background         @bgRed@
+mark2_foreground         @bg@
+mark2_background         @bgBlue@
 mark3_foreground         @bg@
-mark3_background         @bgDarkBlue@
+mark3_background         @bgGreen@
 
 # black
 color0                   @black@

--- a/kitty/template.conf
+++ b/kitty/template.conf
@@ -1,0 +1,60 @@
+foreground               @fg@
+background               @bg@
+
+cursor                   @fg@
+cursor_text_color        @bg@
+
+url_color                @vividBlue@
+
+active_border_color      @emphFg@
+inactive_border_color    @deEmphFg@
+
+bell_border_color        @vividYellow@
+
+active_tab_foreground    @fg@
+active_tab_background    @deEmphFg@
+inactive_tab_foreground  @fg@
+inactive_tab_background  @deEmphBg@
+tab_bar_background       @deEmphBg@
+
+selection_foreground     @fg@
+selection_background     @bgLightYellow@
+
+mark1_foreground         @fg@
+mark1_background         @bgBlue@
+mark2_foreground         @fg@
+mark2_background         @bgYellow@
+mark3_foreground         @bg@
+mark3_background         @bgDarkBlue@
+
+# black
+color0                   @black@
+color8                   @darkGray@
+
+# red
+color1                   @termLowRed@
+color9                   @termHighRed@
+
+# green
+color2                   @termLowGreen@
+color10                  @termHighGreen@
+
+# yellow
+color3                   @termLowYellow@
+color11                  @termHighYellow@
+
+# blue
+color4                   @termLowViolet@
+color12                  @termHighViolet@
+
+# magenta
+color5                   @termLowMagenta@
+color13                  @termHighMagenta@
+
+# cyan
+color6                   @termLowBlue@
+color14                  @termHighBlue@
+
+# white
+color7                   @lightGray@
+color15                  @white@

--- a/kitty/test_colors.py
+++ b/kitty/test_colors.py
@@ -1,0 +1,56 @@
+import sys
+import os
+
+
+colors = ["Black", "Red", "Green", "Yellow", "Blue", "Magenta", "Cyan", "White"]
+
+
+def build_teststring(name, fg):
+    text = [
+        f'{name.ljust(15)}',
+        f'\033[{str(fg)}m',
+        'Normal',
+        '\033[1mBold\033[22m',
+        '\033[3mItalic\033[23m',
+        '\033[4mUnderline\033[24m',
+        '\033[21mDouble Underline\033[24m',
+        '\033[0m',
+        f'\033[{fg + 10}mBackground\033[0m'
+    ]
+
+    return ' '.join(text)
+
+
+def print_colors():
+    colors = [
+        'Black', 'Red', 'Green', 'Yellow',
+        'Blue', 'Magenta', 'Cyan', 'White'
+    ]
+
+    for i in range(0, 8):
+
+        normal_fg = i + 30
+        bright_fg = i + 90
+
+        normal_name = colors[i]
+        bright_name = f'Bright {colors[i]}'
+
+        print(build_teststring(normal_name, normal_fg))
+        print(build_teststring(bright_name, bright_fg))
+
+
+def main():
+    print_colors()
+    print(os.linesep.join([
+        os.linesep,
+        'URL: https://lunaria.design',
+        os.linesep,
+        'MARK1    MARK2    MARK3',
+        'Set the following in your kitty.conf and press F1 to see the colors:',
+        'map f1 toggle_marker text 1 MARK1 2 MARK2 3 MARK3',
+        os.linesep,
+        'SELECTION'
+    ]))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a template for the kitty terminal emulator.

I wasn't able to test all the colors since I don't actually know what `mark1`, `mark2` and `mark3` colors are, but I hope I made some sane choices there.